### PR TITLE
editor: Fixed the extra dockable when adding a tab

### DIFF
--- a/src/main/java/org/editor/EditorWindow.java
+++ b/src/main/java/org/editor/EditorWindow.java
@@ -237,7 +237,7 @@ public final class EditorWindow extends JFrame implements SearchListener {
 
 		// Add first editor normally
 		if (index == 0) {
-			win.desk.addDockable(editor);
+			win.getContentPane().add(editor);
 			win.desk.createTab(win.dashboard, editor, 2);
 		} else {
 			// Add to same container as first editor
@@ -256,6 +256,7 @@ public final class EditorWindow extends JFrame implements SearchListener {
 
 		// Add first editor normally
 		if (index == 0) {
+			win.getContentPane().add(editor);
 			win.desk.createTab(win.dashboard, editor, 2);
 		} else {
 			// Add to same container as first editor


### PR DESCRIPTION
Fixed a minor bug that was happening when adding a new tab. An extra dockable was getting added for every tab that is created. This is because vldocking expects us to add our dockables to the contentPane before managing them. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the way the first editor tab is displayed in the main window for improved integration with the application interface. Subsequent tabs are added as before. No visible changes to controls or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->