### PR TITLE
editor: Fixed the bug when closing ther window

### DIFF
--- a/src/main/java/org/editor/EditorWindow.java
+++ b/src/main/java/org/editor/EditorWindow.java
@@ -213,6 +213,7 @@ public final class EditorWindow extends JFrame implements SearchListener {
 
 		win = this;
 
+		this.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
 		this.setSize(width, height);
 		this.setLocationRelativeTo(null);
 		this.setVisible(true);


### PR DESCRIPTION
I have fixed the bug that was causing the editor to remain in the background after the user closes the editor. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Closing the editor window now properly exits the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->