### PR TITLE
Fix the rampant memory usage that was caused by compiling per…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
 			<artifactId>PiccodeScript</artifactId>
 			<version>main-SNAPSHOT</version>
 		</dependency>
+		
+		<dependency>
+			<groupId>com.github.Glimmr-Lang</groupId>
+			<artifactId>JHLabs</artifactId>
+			<version>main-SNAPSHOT</version>
+		</dependency>
 
 	</dependencies>
 

--- a/src/main/java/org/editor/events/AccessEvents.java
+++ b/src/main/java/org/editor/events/AccessEvents.java
@@ -29,9 +29,7 @@ public class AccessEvents {
 
 		var file = ed.file.toString();
 		var code = ed.textArea.getText();
-		CanvasFrame.file = file;
-		CanvasFrame.code = code;
-		CanvasFrame.start = true;
+		CanvasFrame.the().compile(() -> Compiler.compile(file, code));
 		AccessFrame.writeSuccess("Compilation started: ");
 	}
 

--- a/src/main/java/org/editor/nativemods/PiccodeBrushedMetalFilterModule.java
+++ b/src/main/java/org/editor/nativemods/PiccodeBrushedMetalFilterModule.java
@@ -1,0 +1,112 @@
+package org.editor.nativemods;
+
+import com.jhlabs.image.BrushedMetalFilter;
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.util.HashMap;
+import java.util.List;
+import org.editor.CanvasFrame;
+import org.piccode.rt.Context;
+import org.piccode.rt.PiccodeException;
+import org.piccode.rt.PiccodeNumber;
+import org.piccode.rt.PiccodeObject;
+import org.piccode.rt.PiccodeReference;
+import org.piccode.rt.PiccodeString;
+import org.piccode.rt.PiccodeUnit;
+import org.piccode.rt.PiccodeValue;
+import org.piccode.rt.PiccodeValue.Type;
+import org.piccode.rt.modules.NativeFunctionFactory;
+
+/**
+ *
+ * @author hexaredecimal
+ */
+public class PiccodeBrushedMetalFilterModule {
+
+	public static void addFunctions() {
+		NativeFunctionFactory.create("brush_metal_new", List.of(), (args, namedArgs, frame) -> {
+			var bmFilter = new BrushedMetalFilter();
+			return new PiccodeReference(bmFilter);
+		}, null);
+
+		NativeFunctionFactory.create("brush_metal_set_rad", List.of("filter", "rad"), (args, namedArgs, frame) -> {
+			var _filter = namedArgs.get("filter");
+			var rad = namedArgs.get("rad");
+
+			var ctx = frame == null
+							? Context.top
+							: Context.getContextAt(frame);
+			var caller = ctx.getTopFrame().caller;
+
+			PiccodeValue.verifyType(caller, _filter, Type.REFERENCE);
+			PiccodeValue.verifyType(caller, rad, Type.NUMBER);
+
+			var obj = (PiccodeReference) _filter;
+			var _filter_object = obj.deref();
+			if (!(_filter_object instanceof BrushedMetalFilter)) {
+				throw new PiccodeException(caller.file, caller.line, caller.column, "Filter is not a correct object.");
+			}
+
+			var filter = (BrushedMetalFilter) _filter_object;
+			var radius = (int) (double) ((PiccodeNumber) rad).raw();
+
+			filter.setRadius(radius);
+			
+			return new PiccodeReference(_filter_object);
+		}, null);
+
+		NativeFunctionFactory.create("brush_metal_set_amount", List.of("filter", "amount"), (args, namedArgs, frame) -> {
+			var _filter = namedArgs.get("filter");
+			var amount = namedArgs.get("amount");
+
+			var ctx = frame == null
+							? Context.top
+							: Context.getContextAt(frame);
+			var caller = ctx.getTopFrame().caller;
+
+			PiccodeValue.verifyType(caller, _filter, Type.REFERENCE);
+			PiccodeValue.verifyType(caller, amount, Type.NUMBER);
+
+			var obj = (PiccodeReference) _filter;
+			var _filter_object = obj.deref();
+			if (!(_filter_object instanceof BrushedMetalFilter)) {
+				throw new PiccodeException(caller.file, caller.line, caller.column, "Filter is not a correct object.");
+			}
+
+			var filter = (BrushedMetalFilter) _filter_object;
+			var _amount = (int) (double) ((PiccodeNumber) amount).raw();
+
+			filter.setRadius(_amount);
+			
+			return new PiccodeReference(_filter_object);
+		}, null);
+	
+		NativeFunctionFactory.create("brush_metal_set_shine", List.of("filter", "shine"), (args, namedArgs, frame) -> {
+			var _filter = namedArgs.get("filter");
+			var shine = namedArgs.get("shine");
+
+			var ctx = frame == null
+							? Context.top
+							: Context.getContextAt(frame);
+			var caller = ctx.getTopFrame().caller;
+
+			PiccodeValue.verifyType(caller, _filter, Type.REFERENCE);
+			PiccodeValue.verifyType(caller, shine, Type.NUMBER);
+
+			var obj = (PiccodeReference) _filter;
+			var _filter_object = obj.deref();
+			if (!(_filter_object instanceof BrushedMetalFilter)) {
+				throw new PiccodeException(caller.file, caller.line, caller.column, "Filter is not a correct object.");
+			}
+
+			var filter = (BrushedMetalFilter) _filter_object;
+			var _shine = (int) (double) ((PiccodeNumber) shine).raw();
+
+			filter.setRadius(_shine);
+			
+			return new PiccodeReference(_filter_object);
+		}, null);
+	
+	}
+
+}

--- a/src/main/java/org/editor/nativemods/PiccodeFilterModule.java
+++ b/src/main/java/org/editor/nativemods/PiccodeFilterModule.java
@@ -1,0 +1,57 @@
+package org.editor.nativemods;
+
+import java.awt.image.BufferedImage;
+import java.awt.image.BufferedImageOp;
+import java.util.List;
+import org.piccode.rt.Context;
+import org.piccode.rt.PiccodeException;
+import org.piccode.rt.PiccodeReference;
+import org.piccode.rt.PiccodeValue;
+import org.piccode.rt.PiccodeValue.Type;
+import org.piccode.rt.modules.NativeFunctionFactory;
+
+/**
+ *
+ * @author hexaredecimal
+ */
+public class PiccodeFilterModule {
+
+	public static void addFunctions() {
+		NativeFunctionFactory.create("filter_apply", List.of("filter", "image"), (args, namedArgs, frame) -> {
+			var _filter = namedArgs.get("filter");
+			var image = namedArgs.get("image");
+
+			var ctx = frame == null
+							? Context.top
+							: Context.getContextAt(frame);
+			var caller = ctx.getTopFrame().caller;
+
+			PiccodeValue.verifyType(caller, _filter, Type.REFERENCE);
+			PiccodeValue.verifyType(caller, image, Type.REFERENCE);
+
+			var obj = (PiccodeReference) _filter;
+			var img = (PiccodeReference) image;
+			var _filter_object = obj.deref();
+			var _buffered_image = img.deref();
+			
+			if (!(_filter_object instanceof BufferedImageOp)) {
+				throw new PiccodeException(caller.file, caller.line, caller.column, "Filter is not a correct object.");
+			}
+
+			if (!(_buffered_image instanceof BufferedImage)) {
+				throw new PiccodeException(caller.file, caller.line, caller.column, "Expected a buffer image. Found " + _buffered_image);
+			}
+
+
+			var filter = (BufferedImageOp) _filter_object;
+			var _image = (BufferedImage) _buffered_image;
+
+			var result = filter.filter(_image, null);
+			
+			return new PiccodeReference(result);
+		}, null);
+	
+	
+	}
+
+}

--- a/src/main/java/org/editor/nativemods/PiccodeImageModule.java
+++ b/src/main/java/org/editor/nativemods/PiccodeImageModule.java
@@ -1,0 +1,92 @@
+package org.editor.nativemods;
+
+import java.awt.Color;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.util.HashMap;
+import java.util.List;
+import org.editor.CanvasFrame;
+import org.piccode.rt.Context;
+import org.piccode.rt.PiccodeException;
+import org.piccode.rt.PiccodeNumber;
+import org.piccode.rt.PiccodeObject;
+import org.piccode.rt.PiccodeReference;
+import org.piccode.rt.PiccodeString;
+import org.piccode.rt.PiccodeUnit;
+import org.piccode.rt.PiccodeValue;
+import org.piccode.rt.PiccodeValue.Type;
+import org.piccode.rt.modules.NativeFunctionFactory;
+
+/**
+ *
+ * @author hexaredecimal
+ */
+public class PiccodeImageModule {
+
+	public static void addFunctions() {
+
+		NativeFunctionFactory.create("image_new", List.of("w", "h"), (args, namedArgs, frame) -> {
+			var w = namedArgs.get("w");
+			var h = namedArgs.get("h");
+
+			var ctx = frame == null ? 
+					Context.top
+					: Context.getContextAt(frame);
+			var caller = ctx.getTopFrame().caller;
+			
+			PiccodeValue.verifyType(caller, w, Type.NUMBER);
+			PiccodeValue.verifyType(caller, h, Type.NUMBER);
+
+			var _w = (int) (double) ((PiccodeNumber) w).raw();
+			var _h = (int) (double) ((PiccodeNumber) h).raw();
+
+			var image = new BufferedImage(_w, _h, BufferedImage.TYPE_INT_ARGB);
+			return new PiccodeReference(image);
+		}, null);
+		
+		NativeFunctionFactory.create("image_new_typed", List.of("w", "h", "type"), (args, namedArgs, frame) -> {
+			var w = namedArgs.get("w");
+			var h = namedArgs.get("h");
+			var type = namedArgs.get("type");
+
+			var ctx = frame == null ? 
+					Context.top
+					: Context.getContextAt(frame);
+			var caller = ctx.getTopFrame().caller;
+			
+			PiccodeValue.verifyType(caller, w, Type.NUMBER);
+			PiccodeValue.verifyType(caller, h, Type.NUMBER);
+			PiccodeValue.verifyType(caller, type, Type.NUMBER);
+
+			var _w = (int) (double) ((PiccodeNumber) w).raw();
+			var _h = (int) (double) ((PiccodeNumber) h).raw();
+			var _type = (int) (double) ((PiccodeNumber) type).raw();
+
+			var image = new BufferedImage(_w, _h, _type);
+			return new PiccodeReference(image);
+		}, null);
+	
+		NativeFunctionFactory.create("image_get_context", List.of("img"), (args, namedArgs, frame) -> {
+			var img = namedArgs.get("img");
+
+			var ctx = frame == null ? 
+					Context.top
+					: Context.getContextAt(frame);
+			var caller = ctx.getTopFrame().caller;
+			
+			PiccodeValue.verifyType(caller, img, Type.REFERENCE);
+
+			var _buffered_image = ((PiccodeReference)img).deref();
+
+			if (!(_buffered_image instanceof BufferedImage)) {
+				throw new PiccodeException(caller.file, caller.line, caller.column, "Expected a buffer image. Found " + _buffered_image);
+			}
+
+			var bufferedmage = (BufferedImage) _buffered_image;
+			var gfx = bufferedmage.createGraphics();
+			return new PiccodeReference(gfx);
+		}, null);
+	
+	}
+
+}


### PR DESCRIPTION
Before we were compiling the source code each frame in order to draw on the screen. Now I simply render to a bufferedImage that is the same size as the render window and then draw that image on top of the grid. 
- This change reduced the CPU usage from 45%-55% to 6%-8%
- This also reduced the Memory usage from 400MB-450MB when rendering to 250MB-280MB
<img width="1320" height="64" alt="image" src="https://github.com/user-attachments/assets/b0c0a7bb-de24-46c1-9f89-95f9411b49f7" />
This change also introduces the first commits for JHLabs filters support


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and manipulating images and image filters within the Piccode environment, including new native functions for image creation, filter application, and brushed metal filter customization.

* **Refactor**
  * Improved the rendering pipeline for the canvas, separating rendering into an offscreen image and updating how custom drawing logic is supplied and executed.

* **Bug Fixes**
  * Enhanced resource management by explicitly disposing of graphics contexts after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->